### PR TITLE
fix: 目录中的摘要后面加冒号

### DIFF
--- a/ecnuthesis.cls
+++ b/ecnuthesis.cls
@@ -1072,7 +1072,7 @@
 \cs_new_protected:Npn \__ecnu_abstract_begin:
   { 
     \phantomsection
-    \addcontentsline{toc}{chapter}{摘要}
+    \addcontentsline{toc}{chapter}{摘要：}
     \__ecnu_title:V \l__ecnu_info_title_tl
     \mode_leave_vertical: \par \noindent
     \zihao{5}
@@ -1084,7 +1084,7 @@
 \cs_new_protected:Npn \__ecnu_abstractEN_begin:
   { 
     \phantomsection
-    \addcontentsline{toc}{chapter}{ABSTRACT}
+    \addcontentsline{toc}{chapter}{ABSTRACT:}
     \__ecnu_title:V { \rmfamily\bfseries \l__ecnu_info_titleEN_tl }
     \mode_leave_vertical: \par \noindent
     \zihao{5}


### PR DESCRIPTION
虽然我不觉得目录里面应该加冒号，但学校发的模板里面确实加了：

![image](https://user-images.githubusercontent.com/25550534/231379212-2802a7a2-81b8-4304-8694-30cd1a0464bf.png)
